### PR TITLE
PR8: Storage plugins (Local + S3)

### DIFF
--- a/api/app/plugins/storage/local/manifest.json
+++ b/api/app/plugins/storage/local/manifest.json
@@ -1,0 +1,12 @@
+{
+  "id": "local",
+  "name": "Local Storage",
+  "version": "1.0.0",
+  "type": "storage",
+  "traits": {
+    "store_file": true,
+    "kms_supported": false,
+    "endpoint_url_supported": false
+  },
+  "config_schema": { "type": "object", "properties": {} }
+}

--- a/api/app/plugins/storage/s3/manifest.json
+++ b/api/app/plugins/storage/s3/manifest.json
@@ -1,0 +1,13 @@
+{
+  "id": "s3",
+  "name": "S3 Storage",
+  "version": "1.0.0",
+  "type": "storage",
+  "traits": {
+    "store_file": true,
+    "kms_supported": true,
+    "endpoint_url_supported": true,
+    "regions": []
+  },
+  "config_schema": { "type": "object", "properties": {} }
+}

--- a/api/app/plugins/storage/shims/local/plugin.py
+++ b/api/app/plugins/storage/shims/local/plugin.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Tuple, IO
+
+from api.app.storage import LocalStorage
+
+
+class Plugin:
+    plugin_type = "storage"
+    plugin_id = "local"
+
+    def __init__(self) -> None:
+        self._impl = LocalStorage()
+
+    async def initialize(self, config: dict[str, Any]) -> None:
+        return None
+
+    # Thin wrappers to underlying storage interface
+    def put_pdf(self, local_path: str, object_name: str) -> str:
+        return self._impl.put_pdf(local_path, object_name)
+
+    def get_pdf_stream(self, uri: str) -> Tuple[IO[bytes], str]:
+        return self._impl.get_pdf_stream(uri)
+
+    def delete(self, uri: str) -> None:
+        return self._impl.delete(uri)
+

--- a/api/app/plugins/storage/shims/s3/plugin.py
+++ b/api/app/plugins/storage/shims/s3/plugin.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any, Tuple, IO
+
+from api.app.storage import S3Storage
+
+
+class Plugin:
+    plugin_type = "storage"
+    plugin_id = "s3"
+
+    def __init__(self) -> None:
+        # Initialize S3 client from settings
+        self._impl = S3Storage()
+
+    async def initialize(self, config: dict[str, Any]) -> None:
+        return None
+
+    def put_pdf(self, local_path: str, object_name: str) -> str:
+        return self._impl.put_pdf(local_path, object_name)
+
+    def get_pdf_stream(self, uri: str) -> Tuple[IO[bytes], str]:
+        return self._impl.get_pdf_stream(uri)
+
+    def delete(self, uri: str) -> None:
+        return self._impl.delete(uri)
+


### PR DESCRIPTION
- Adds storage shims for Local and S3 and their manifests
- Manager already supports 'storage' discovery (from PR6)
- No behavior change; storage ops remain via existing paths

Acceptance:
- Storage manifests present; discovery loads when shims exist
- OpenAPI unchanged