### PR TITLE
p4(api): Admin marketplace listing endpoint (gated)

### DIFF
--- a/api/admin_ui/src/components/PluginMarketplace.tsx
+++ b/api/admin_ui/src/components/PluginMarketplace.tsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { Box, Typography, TextField, InputAdornment, Grid, Card, CardContent } from '@mui/material';
+import SearchIcon from '@mui/icons-material/Search';
+
+/**
+ * Minimal placeholder for the Admin Console Plugin Marketplace.
+ * - Strict TypeScript compliant (no unused vars)
+ * - Not wired into the App shell yet; safe to compile
+ * - No provider name checks; trait‑gated wiring will come in later PRs
+ */
+export default function PluginMarketplace(): JSX.Element {
+  const [query, setQuery] = useState('');
+
+  return (
+    <Box sx={{ px: { xs: 1, sm: 2, md: 3 }, py: 2 }}>
+      <Typography variant="h4" sx={{ mb: 2 }}>
+        Plugin Marketplace
+      </Typography>
+
+      <TextField
+        fullWidth
+        placeholder="Search plugins…"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        InputProps={{
+          startAdornment: (
+            <InputAdornment position="start">
+              <SearchIcon />
+            </InputAdornment>
+          ),
+        }}
+        sx={{ mb: 3 }}
+      />
+
+      <Grid container spacing={2}>
+        {/* Empty state placeholder; results will be populated in later PRs */}
+        <Grid item xs={12}>
+          <Card variant="outlined">
+            <CardContent>
+              <Typography color="text.secondary">
+                Marketplace results will appear here. Use traits to gate provider‑specific UI.
+              </Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}
+

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -316,6 +316,14 @@ except Exception:
     # Non-fatal if health monitoring deps missing
     pass
 
+# Admin marketplace (Phase 4; disabled by default)
+try:
+    from .routers import admin_marketplace as _marketplace
+    app.include_router(_marketplace.router)
+except Exception:
+    # Non-fatal if marketplace router cannot be imported
+    pass
+
 # Webhook hardening router (DLQ + idempotency)
 try:
     from .routers import webhooks_v2 as _webhooks_v2

--- a/api/app/routers/admin_marketplace.py
+++ b/api/app/routers/admin_marketplace.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import os
+from typing import Optional
+from fastapi import APIRouter, Depends, Header, HTTPException
+from api.app.config import settings
+from api.app.auth import verify_db_key
+
+
+def require_admin(x_api_key: Optional[str] = Header(default=None)):
+    """Minimal admin auth dependency for marketplace endpoints.
+    - Accepts env bootstrap API key
+    - Or a DB-backed key with scope keys:manage
+    """
+    if settings.api_key and x_api_key == settings.api_key:
+        return {"admin": True, "key_id": "env"}
+    info = verify_db_key(x_api_key)
+    if not info or ("keys:manage" not in (info.get("scopes") or [])):
+        raise HTTPException(401, detail="Admin authentication failed")
+    return info
+
+
+router = APIRouter(prefix="/admin/marketplace", tags=["AdminMarketplace"], dependencies=[Depends(require_admin)])
+
+
+@router.get("/plugins")
+def list_plugins():
+    """List available plugins in the marketplace (disabled by default).
+
+    Gate with ADMIN_MARKETPLACE_ENABLED=false by default to avoid exposing in prod
+    until features are complete.
+    """
+    enabled = os.getenv("ADMIN_MARKETPLACE_ENABLED", "false").lower() in {"1", "true", "yes"}
+    if not enabled:
+        # Hide endpoint when disabled to avoid confusing operators
+        raise HTTPException(404, detail="Not found")
+    # Placeholder: will be populated via trait‑aware registry in later PRs
+    return {"plugins": []}
+


### PR DESCRIPTION
Adds /admin/marketplace/plugins (admin auth) returning an empty list. Gated by ADMIN_MARKETPLACE_ENABLED=false (404 when disabled). Wired into app under guarded import. No behavior change by default.