### PR TITLE
fix: add sessionIdGenerator to StreamableHTTPServerTransport

### DIFF
--- a/node_mcp/src/servers/http.js
+++ b/node_mcp/src/servers/http.js
@@ -6,6 +6,7 @@ import morgan from 'morgan';
 import dotenv from 'dotenv';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import crypto from 'node:crypto';
 import { buildServer } from './stdio.js';
 
 dotenv.config();
@@ -68,7 +69,9 @@ app.post('/mcp', checkAuth, async (req, res) => {
           id: null,
         });
       }
-      const transport = new StreamableHTTPServerTransport({});
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => crypto.randomUUID(),
+      });
       const server = await initServerWithTransport(transport);
       // Process initialize request; the transport will assign sessionId and set header
       await transport.handleRequest(req, res, req.body);


### PR DESCRIPTION
## Summary
- The MCP SDK v1.17.5 requires `sessionIdGenerator` in the `StreamableHTTPServerTransport` constructor options
- Passing `{}` omitted this required field, causing a 500 Internal Server Error on every `initialize` request
- Added `sessionIdGenerator: () => crypto.randomUUID()` to enable stateful session management

## Test plan
- [ ] Restart the MCP HTTP server
- [ ] Send an initialize request to `POST /mcp` with Bearer auth
- [ ] Verify a successful JSON-RPC response with `Mcp-Session-Id` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)